### PR TITLE
Support unions

### DIFF
--- a/src/CheckConcreteStructs.jl
+++ b/src/CheckConcreteStructs.jl
@@ -129,7 +129,14 @@ function recursive_isconcretetype(T)
     isa(T, TypeVar) && return true  # key modification
     isconcretetype(T) && return true
     isabstracttype(T) && return false
-    for subT in fieldtypes(T)
+    if isa(T, Union)
+        subTs = Base.uniontypes(T)
+        # If inference will give up on this union, report as `false`.
+        length(subTs) > Core.Compiler.MAX_TYPEUNION_LENGTH && return false
+    else
+        subTs = fieldtypes(T)
+    end
+    for subT in subTs
         recursive_isconcretetype(subT) || return false
     end
     return true

--- a/test/invalid.jl
+++ b/test/invalid.jl
@@ -53,3 +53,7 @@ end
     x::Int
     y::Tuple{T1,Array{T2}}
 end
+
+@test_throws AbstractFieldError @check_concrete struct I24{T1}
+    x::Union{T1, Int, Float32, Float64}
+end

--- a/test/valid.jl
+++ b/test/valid.jl
@@ -50,3 +50,11 @@ end
     y::Vector{T2}
     z::Vector{Tuple{T2,Int}}
 end
+
+@check_concrete struct V51{T1}
+    x::Union{T1, Int}
+end
+
+@check_concrete struct V52{T1}
+    x::Union{T1, Int, Float64}
+end


### PR DESCRIPTION
It might be better to emit a nicer error message explaining why we fail the check in that case, but at least it won't error (as it currently does) on unions.