### PR TITLE
Use a function to check a posteriori

### DIFF
--- a/test/invalid.jl
+++ b/test/invalid.jl
@@ -63,13 +63,13 @@ end
     y::Vector{Any}
 end
 
-@test_throws AbstractFieldError @eval Base.@kwdef @check_concrete mutable struct I26{T1}
+@test_throws AbstractFieldError @eval @check_concrete Base.@kwdef mutable struct I26{T1}
     const x::T1
     y::AbstractVector{Any} = []
     const z::Int = 3
 end
 
-@test_throws AbstractFieldError @eval Base.@kwdef @check_concrete mutable struct I27{T1}
+@test_throws AbstractFieldError @eval @check_concrete Base.@kwdef mutable struct I27{T1}
     const x::T1
     y::Vector{Any} = []
     const z::Real = 3

--- a/test/invalid.jl
+++ b/test/invalid.jl
@@ -57,3 +57,20 @@ end
 @test_throws AbstractFieldError @check_concrete struct I24{T1}
     x::Union{T1, Int, Float32, Float64}
 end
+
+@test_throws AbstractFieldError @check_concrete mutable struct I25{T1}
+    const x::Real
+    y::Vector{Any}
+end
+
+@test_throws AbstractFieldError @eval Base.@kwdef @check_concrete mutable struct I26{T1}
+    const x::T1
+    y::AbstractVector{Any} = []
+    const z::Int = 3
+end
+
+@test_throws AbstractFieldError @eval Base.@kwdef @check_concrete mutable struct I27{T1}
+    const x::T1
+    y::Vector{Any} = []
+    const z::Real = 3
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,21 @@ using Test
         include("invalid.jl")
     end
 
+    @testset "Checking modules" begin
+        m = @eval module $(gensym(:TestModule))
+            struct Good{T1}
+                x::T1
+                y::Vector{Any}
+            end
+
+            struct Bad{T1}
+                x::Real
+                y::Vector{T1}
+            end
+        end
+        @test_throws "in struct `Bad`: field `x`" check_concrete(m)
+    end
+
     @testset "Error display" begin
         err = AbstractFieldError(:MyStruct, :myfield, Any)
         buf = IOBuffer()

--- a/test/valid.jl
+++ b/test/valid.jl
@@ -58,3 +58,28 @@ end
 @check_concrete struct V52{T1}
     x::Union{T1, Int, Float64}
 end
+
+@check_concrete mutable struct V53{T1}
+    const x::T1
+    y::Vector{Any}
+end
+
+@check_concrete Base.@kwdef mutable struct V54{T1}
+    const x::T1
+    y::Vector{Any} = []
+    const z::Int = 3
+end
+
+@test V54{Int}(; x = 2) isa V54
+@test isconst(V54, :x)
+
+"Struct definition."
+Base.@kwdef @check_concrete mutable struct V55{T1}
+    const x::T1
+    y::Vector{Any} = []
+    const z::Int = 3
+end
+
+@test V55{Int}(; x = 2) isa V55
+@test isconst(V55, :x)
+@test "Struct definition.\n" == string(@eval @doc V55)

--- a/test/valid.jl
+++ b/test/valid.jl
@@ -74,7 +74,7 @@ end
 @test isconst(V54, :x)
 
 "Struct definition."
-Base.@kwdef @check_concrete mutable struct V55{T1}
+@check_concrete Base.@kwdef mutable struct V55{T1}
     const x::T1
     y::Vector{Any} = []
     const z::Int = 3

--- a/test/valid.jl
+++ b/test/valid.jl
@@ -82,4 +82,3 @@ end
 
 @test V55{Int}(; x = 2) isa V55
 @test isconst(V55, :x)
-@test "Struct definition.\n" == string(@eval @doc V55)


### PR DESCRIPTION
If you're satisfied with this one, you may disregard #5 as I based this PR on it to keep tests but removed the changes to `src` introduced there.

The only downside I see so far (which is a limitation of the `Base.@kwdef` implementation) is that one needs to do `@check_concrete Base.@kwdef` in that order, instead of `Base.@kwdef @check_concrete`.