### PR TITLE
Exclude non-datatypes + abstract types in all_concrete(...)

### DIFF
--- a/src/CheckConcreteStructs.jl
+++ b/src/CheckConcreteStructs.jl
@@ -126,6 +126,8 @@ function all_concrete(M::Module; verbose::Bool=true)
     for name in names(M; all=true)
         x = getproperty(M, name)
         isa(x, Type) || continue
+        isa(x, Union) && continue
+        isabstracttype(x) && continue
         parentmodule(x) === M || continue
         if !all_concrete(x; verbose)
             concrete = false

--- a/test/modules.jl
+++ b/test/modules.jl
@@ -32,3 +32,10 @@ end
     :warn,
     "AbstractFieldError in struct `Bad`: field `x` with declared type `Real` is not concretely typed.",
 ) !all_concrete(M2)
+
+M3 = @eval module $(gensym(:TestModule))
+abstract type DontCheckMe end
+TypeAlias = Union{Int, Float64}
+end
+
+@test all_concrete(M3; verbose=false)


### PR DESCRIPTION
Currently checking a module will cause an exception if there is an `abstract type` (indeterminate number of fields) or a type alias to a `Union{...}` (methoderror on parentmodule).

These extra guards should fix things.